### PR TITLE
improve grounded plan representation

### DIFF
--- a/src/parser/utap_trace_parser.cpp
+++ b/src/parser/utap_trace_parser.cpp
@@ -496,10 +496,19 @@ timed_trace_t UTAPTraceParser::getTimedTrace(const Automaton &base_ta,
   std::vector<SpecialClocksInfo> trace_timings = getTraceTimings();
   timed_trace_t res;
   assert(trace_timings.size() == trace_ta.transitions.size() + 1);
+  // the last transition goes to fin, hence we skip it
   for (size_t i = 0; i < trace_ta.transitions.size() - 1; i++) {
     GroundedActionTime curr_action_grounding;
+    // global clock lower bound of the symbolic state after the transition
+    // gives the earliest possible action start
     curr_action_grounding.earliest_start =
         (trace_timings.begin() + i + 1)->global_clock.first.first;
+    // max delay of the symbolic state before the transition describes
+    // how much time may elapse while not taking the transition without
+    // breaking any constraint.
+    // Using this together with the difference of global clock lower bound
+    // values of the next symbolic state and the previous one gives the
+    // possible delay added on top of the earliest action start
     curr_action_grounding.max_delay =
         (trace_timings.begin() + i)->max_delay.first +
         (trace_timings.begin() + i)->global_clock.first.first -

--- a/src/parser/utap_trace_parser.h
+++ b/src/parser/utap_trace_parser.h
@@ -25,9 +25,20 @@ typedef ::std::pair<taptenc::timepoint, bool> dbm_entry_t;
 struct specialClocksInfo {
   ::std::pair<dbm_entry_t, dbm_entry_t> global_clock;
   dbm_entry_t max_delay;
-	friend std::ostream& operator<<(std::ostream& os, const specialClocksInfo &g);
+  friend std::ostream &operator<<(std::ostream &os, const specialClocksInfo &g);
 };
 typedef specialClocksInfo SpecialClocksInfo;
+
+/**
+ * Wrapper for plan action timings.
+ */
+struct groundedActionTime {
+  taptenc::timepoint earliest_start;
+  taptenc::timepoint max_delay;
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const groundedActionTime &g);
+};
+typedef groundedActionTime GroundedActionTime;
 
 /**
  * Different bounds representation, where [clock1,clock2] -> (i,true) means
@@ -42,7 +53,7 @@ typedef ::std::unordered_map<::std::pair<::std::string, ::std::string>,
  * started after the time constraints are met.
  */
 typedef ::std::vector<
-    ::std::pair<SpecialClocksInfo, ::std::vector<::std::string>>>
+    ::std::pair<groundedActionTime, ::std::vector<::std::string>>>
     timed_trace_t;
 
 class UTAPTraceParser {


### PR DESCRIPTION
While the model checker implicitly gives grounded plans, the relevant temporal information is not explicitly represented anywhere.
This information is.
1) the earliest (= desired) execution start of each action
2) the maximum possible delay of missing the execution start before
   the calculated solution trace cannot re-ground execution times

In order to get the relevant information from the symbolic states before and after a transition (= action) is taken, one can simply look at the lower bound `l_d` of the global clock in the destination symbolic state, which directly corresponds to 1).
2) can be obtained by looking at the max delay `d` of the source symbolic state, which describes given the lower bound `l_s` of the source symbolic state, how much time may elapse in the source symbolic state without breaking any bound. Hence `b + l_s - l_d` provides the maximum delay applied to `l_d` before the solution trace becomes invalid.