### PR TITLE
Only call tracer if query was satisfied

### DIFF
--- a/buildsys/compiler_vars.mk
+++ b/buildsys/compiler_vars.mk
@@ -8,7 +8,7 @@ POSTCOMPILE = mv -f $(DEP_DIR)/$*.Td $(DEP_DIR)/$*.d && touch $@
 
 CXXFLAGS.debug := -Og -fstack-protector-all -g
 CXXFLAGS.release := -O3 -march=native -DNDEBUG
-CXXFLAGS := -pthread -std=gnu++14 -W{all,extra,error} -fmessage-length=0 ${CXXFLAGS.${BUILD}}
+CXXFLAGS := -pthread -std=gnu++17 -W{all,extra,error} -fmessage-length=0 ${CXXFLAGS.${BUILD}}
 
 LDFLAGS.debug :=
 LDFLAGS.release :=

--- a/src/uppaal_calls.cpp
+++ b/src/uppaal_calls.cpp
@@ -11,6 +11,7 @@
 #include "timed-automata/timed_automata.h"
 #include "utils.h"
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -78,9 +79,11 @@ std::string exec(const char *cmd) {
 ::std::vector<timedelta> solve(std::string file_name, std::string query_str) {
   std::vector<timedelta> res;
   std::ofstream myfile;
+  std::filesystem::remove(file_name + ".q");
   myfile.open(file_name + ".q", std::ios_base::trunc);
   myfile << query_str;
   myfile.close();
+  std::filesystem::remove(file_name + ".if");
   std::string call_get_if = "UPPAAL_COMPILE_ONLY=1 " +
                             getEnvVar("VERIFYTA_DIR") + "/verifyta " +
                             file_name + ".xml - > " + file_name + ".if";
@@ -92,6 +95,7 @@ std::string exec(const char *cmd) {
   std::string call_get_trace = getEnvVar("VERIFYTA_DIR") +
                                "/verifyta -t 2  -f " + file_name + " -Y " +
                                file_name + ".xml " + file_name + ".q";
+  std::filesystem::remove(file_name + "-1.xtr");
   t1 = std::chrono::high_resolution_clock::now();
   // std::system(call_get_trace.c_str());
   std::string output_str = exec(call_get_trace.c_str());
@@ -102,6 +106,7 @@ std::string exec(const char *cmd) {
 
     t1 = std::chrono::high_resolution_clock::now();
     deleteEmptyLines(file_name + "-1.xtr");
+    std::filesystem::remove(file_name + ".trace");
     std::string call_make_trace_readable = "tracer " + file_name + ".if " +
                                            file_name + "-1.xtr > " + file_name +
                                            ".trace";

--- a/src/uppaal_calls.cpp
+++ b/src/uppaal_calls.cpp
@@ -52,6 +52,20 @@ std::string getEnvVar(std::string const &key) {
   return std::string(val);
 }
 
+std::string exec(const char *cmd) {
+  std::array<char, 128> buffer;
+  std::string result;
+  std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+  if (!pipe)
+    throw std::runtime_error("popen() failed!");
+  while (!feof(pipe.get())) {
+    if (fgets(buffer.data(), 128, pipe.get()) != nullptr)
+      result += buffer.data();
+  }
+  return result;
+}
+
+
 ::std::vector<timedelta> solve(const AutomataSystem &sys, std::string file_name,
                                std::string query_str) {
   XMLPrinter printer;
@@ -59,6 +73,8 @@ std::string getEnvVar(std::string const &key) {
   printer.print(sys, sys_vis_info, file_name + ".xml");
   return solve(file_name, query_str);
 }
+
+
 ::std::vector<timedelta> solve(std::string file_name, std::string query_str) {
   std::vector<timedelta> res;
   std::ofstream myfile;
@@ -77,18 +93,23 @@ std::string getEnvVar(std::string const &key) {
                                "/verifyta -t 2  -f " + file_name + " -Y " +
                                file_name + ".xml " + file_name + ".q";
   t1 = std::chrono::high_resolution_clock::now();
-  std::system(call_get_trace.c_str());
+  // std::system(call_get_trace.c_str());
+  std::string output_str = exec(call_get_trace.c_str());
   t2 = std::chrono::high_resolution_clock::now();
-  res.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1));
+  res.push_back(
+      std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1));
+  if (output_str.find("formula is satisfied")) {
 
-  t1 = std::chrono::high_resolution_clock::now();
-  deleteEmptyLines(file_name + "-1.xtr");
-  std::string call_make_trace_readable = "tracer " + file_name + ".if " +
-                                         file_name + "-1.xtr > " + file_name +
-                                         ".trace";
-  std::system(call_make_trace_readable.c_str());
-  t2 = std::chrono::high_resolution_clock::now();
-  res.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1));
+    t1 = std::chrono::high_resolution_clock::now();
+    deleteEmptyLines(file_name + "-1.xtr");
+    std::string call_make_trace_readable = "tracer " + file_name + ".if " +
+                                           file_name + "-1.xtr > " + file_name +
+                                           ".trace";
+    std::system(call_make_trace_readable.c_str());
+    t2 = std::chrono::high_resolution_clock::now();
+    res.push_back(
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1));
+  }
   return res;
 }
 } // end namespace uppaalcalls

--- a/src/uppaal_calls.h
+++ b/src/uppaal_calls.h
@@ -45,8 +45,8 @@ std::string getEnvVar(std::string const &key);
  * @param file_name name of xml system file without .xml
  * @param query_str query string suitable for uppaal
  *
- * @return time measures fo the two calls to verifyta and the one call to
- *         tracer
+ * @return time measures for the two calls to verifyta and if the query is
+ *         satisfied then also for the call to tracer
  */
 ::std::vector<timedelta> solve(::std::string file_name = TAPTENC_TEMP_XML,
                                ::std::string query_str = QUERY_STR);
@@ -59,8 +59,8 @@ std::string getEnvVar(std::string const &key);
  * @param file_name name of xml system file without .xml
  * @param query_str query string sutiable for uppaal
  *
- * @return time measures fo the two calls to verifyta and the one call to
- *         tracer
+ * @return time measures for the two calls to verifyta and if the query is
+ *         satisfied then also for the call to tracer
  */
 ::std::vector<timedelta> solve(const AutomataSystem &sys,
                                ::std::string file_name = TAPTENC_TEMP_XML,


### PR DESCRIPTION
It does not make sense to run the tracer when no trace file exists. Previously this could easily result in segfaults if old traces from different automata were present.
Additionally delete all old copies of files before they are created.