### PR TITLE
fix a bunch of compiler warnings

### DIFF
--- a/src/constraints/constraints.cpp
+++ b/src/constraints/constraints.cpp
@@ -182,7 +182,7 @@ bounds::bounds(timepoint l, timepoint u, ComparisonOp arg_l_op,
   assert(arg_l_op == ComparisonOp::LT || arg_l_op == ComparisonOp::LTE);
   assert(arg_r_op == ComparisonOp::LT || arg_r_op == ComparisonOp::LTE);
   assert(arg_r_op == ComparisonOp::LT ||
-         upper_bound != std::numeric_limits<timepoint>::max());
+         u != std::numeric_limits<timepoint>::max());
   l_op = arg_l_op;
   r_op = arg_r_op;
   lower_bound = l;

--- a/src/constraints/constraints.h
+++ b/src/constraints/constraints.h
@@ -101,6 +101,9 @@ enum CCType {
 struct clockConstraint {
   /** Holds the real type concrete object type. */
   CCType type;
+
+  virtual ~clockConstraint() = default;
+
   /** Copies interface to allow clock constraint copies extended by more
    * constraints during encoding.
    */

--- a/src/parser/utap_trace_parser.cpp
+++ b/src/parser/utap_trace_parser.cpp
@@ -159,9 +159,7 @@ UTAPTraceParser::determineSpecialClockBounds(dbm_t differences) {
     trace_to_ta_ids.insert(std::make_pair(ta_state_id, source_state_it->id));
     trace_ta.states.push_back(ta_state);
   } else {
-    std::cout
-        << "UTAPTraceParser addStateToTraceTA: Error, source state not found: "
-        << state_id << std::endl;
+    throw std::runtime_error("UTAPTraceParser addStateToTraceTA: Error, source state not found: " + state_id);
   }
   return ta_state_id;
 }

--- a/src/timed-automata/timed_automata.cpp
+++ b/src/timed-automata/timed_automata.cpp
@@ -65,7 +65,7 @@ state::state(const state &other) {
 }
 state::state(state &&other) noexcept {
   id = std::move(other.id);
-  inv = std::move(other.inv->createCopy());
+  inv = other.inv->createCopy();
   urgent = std::move(other.urgent);
   initial = std::move(other.initial);
 }


### PR DESCRIPTION
This addresses a few issues found by the clang code model. One of them was an actual bug in that one of the assertions in the `bounds` c'tor was actually undefined behavior. The rest is just cleanup.